### PR TITLE
Old code regarded all non-ASCII chars as control.

### DIFF
--- a/Packages/Text Integration Utility/Routines/TIULF.m
+++ b/Packages/Text Integration Utility/Routines/TIULF.m
@@ -1,5 +1,8 @@
-TIULF ; SLC/JER - More computational functions ; 4/2/03
- ;;1.0;TEXT INTEGRATION UTILITIES;**162**;Jun 20, 1997
+TIULF ; SLC/JER - More computational functions ;9월 06, 2018@15:15
+ ;;1.0;TEXT INTEGRATION UTILITIES;**162,10001**;Jun 20, 1997
+ ;
+ ; *10001* Changes (c) Sam Habiel
+ ; Licensed under Apache 2.0.
  ;
 STATUS(TIUDA) ; Returns external status for document TIUDA
  Q $$GET1^DIQ(8925,TIUDA_",",.05)
@@ -17,7 +20,7 @@ EMPTYDOC(DA) ;Checks to see if text for DCS is blank
  . . ;Data between two | indicates format command and not valid data 
  . . F TIUSTART=TIUSTART:1:TIUQUIT S TIUCHAR=$E(TIUDATA,TIUSTART) D  Q:(TIUY=0)
  . . . ;Char is not a control char or | char
- . . . I $A(TIUCHAR)'<33&($A(TIUCHAR)'>123)!($A(TIUCHAR)=125) S TIUY=0 Q
+ . . . I TIUCHAR'=124,TIUCHAR'?1C S TIUY=0 Q  ; *10001*; Previously, individual ASCII chars where checked (<32 & >125)
  . . . I $A(TIUCHAR)=124 D  ;Char is a |
  . . . . S TIUX=$F(TIUDATA,"|",TIUSTART+1) ;Find second |
  . . . . I TIUX>TIUSTART S TIUSTART=TIUX-1 ;Making sure there is a second |


### PR DESCRIPTION
Document empty check came up as empty if there were no ASCII characters
in the document (i.e. Unicode only document).

I changed this so that it would use the standard M check for control
characters, which also works for Unicode (X?C).