### PR TITLE
Cache Plan VI support and $$ENV call for GTM/Cache

### DIFF
--- a/Packages/Kernel/Routines/ZOSVGUX.m
+++ b/Packages/Kernel/Routines/ZOSVGUX.m
@@ -1,4 +1,4 @@
-%ZOSV ;VEN/SMH,KRM/CJE,FIS/KSB - View commands & special functions. ;Nov 23, 2018@15:02
+%ZOSV ;VEN/SMH,KRM/CJE,FIS/KSB - View commands & special functions. ;Dec 06, 2018@11:40
  ;;8.0;KERNEL;**275,425,499,10001,10002,10004,10005**;Jul 10, 1995;Build 25
  ; Submitted to OSEHRA in 2017 by Sam Habiel for OSEHRA
  ; Original Routine authored by Department of Veterans Affairs
@@ -276,4 +276,7 @@ BL(X) ; Byte Length of X in UTF-8 encoding
  ;
 BE(X,S,E) ; Byte Extract of X in UTF-8 encoding
  Q $ZE(X,S,E)
+ ;
+ENV(X) ; Get Environment Variable from Operating System
+ Q $ZTRNLNM(X)
  ; /*10005*

--- a/Packages/Kernel/Routines/ZOSVONT.m
+++ b/Packages/Kernel/Routines/ZOSVONT.m
@@ -1,7 +1,7 @@
-%ZOSV ;SFISC/AC - $View commands for Open M for NT.  ; 6/5/18 3:23pm
- ;;8.0;KERNEL;**34,94,107,118,136,215,293,284,385,425,440,499,10002**;Jul 10, 1995;Build 26
+%ZOSV ;SFISC/AC - $View commands for Open M for NT.  ;Dec 06, 2018@11:52
+ ;;8.0;KERNEL;**34,94,107,118,136,215,293,284,385,425,440,499,10002,10005**;Jul 10, 1995;Build 24
  ;
- ; *10002 changes (c) 2018 Sam Habiel
+ ; *10002,*10005 changes (c) 2018 Sam Habiel
  ; Licensed under Apache 2
  ;
 ACTJ() ;# Active jobs
@@ -195,3 +195,14 @@ RETURN(%COMMAND,JUSTSTATUS) ; [Public] execute a shell command - *10002* OSE/SMH
  N OUT R OUT:2
  U OLDIO C %COMMAND
  Q OUT
+ ;
+ ; *10005* Plan VI Calls for VistA Internationalization
+BL(X) ; Byte Length of X in UTF-8 encoding
+ Q $L($ZCONVERT(string,"O","UTF8"))
+ ;
+BE(X,S,E) ; Byte Extract of X in UTF-8 encoding
+ Q $E($ZCONVERT(string,"O","UTF8"),S,E)
+ ;
+ENV(X) ; Get Environment Variable from Operating System
+ Q $SYSTEM.Util.GetEnviron(X)
+ ; /*10005*


### PR DESCRIPTION
For UTF-8 communication, implementation of $$BL and $$BE for Cache.

For being able to grab environment variable, such as API secrets, in
a platform independent way, $$ENV^%ZOSV now exists. Needed for Plan 6
API calls.